### PR TITLE
Refactor: Move classes to 'models' package for clarity

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -1,4 +1,3 @@
-package utility;
 import UI.SplashScreenUI;
 
 public class Main {

--- a/src/UI/SubstitutionUI.java
+++ b/src/UI/SubstitutionUI.java
@@ -1,9 +1,9 @@
 package UI;
 
 import models.UserProfile;
-import services.NutrientInfo;
+import models.NutrientInfo;
 import services.Substitution;
-import services.SubstitutionRecord;
+import models.SubstitutionRecord;
 import utility.ConnectionProvider;
 
 import javax.swing.*;

--- a/src/models/NutrientInfo.java
+++ b/src/models/NutrientInfo.java
@@ -1,4 +1,4 @@
-package services;
+package models;
 
 public class NutrientInfo {
     private final float value;

--- a/src/models/SubstitutionRecord.java
+++ b/src/models/SubstitutionRecord.java
@@ -1,4 +1,4 @@
-package services;
+package models;
 
 import java.time.LocalDate;
 

--- a/src/services/Substitution.java
+++ b/src/services/Substitution.java
@@ -1,5 +1,7 @@
 package services;
 
+import models.NutrientInfo;
+import models.SubstitutionRecord;
 import utility.ConnectionProvider;
 import java.sql.*;
 import java.time.LocalDate;


### PR DESCRIPTION
Relocated 'SubstitutionRecord' and 'NutrientInfo' from 'services' to 'models' to better align with their purpose and structure. Adjusted imports across files to reflect the package changes. Simplified the 'Main' class by removing it from the 'utility' package.